### PR TITLE
(fix): Required parameter  follows optional parameter

### DIFF
--- a/src/Oracle/Oci/Common/HttpUtils.php
+++ b/src/Oracle/Oci/Common/HttpUtils.php
@@ -163,7 +163,7 @@ class HttpUtils
      * @return mixed|null the value indicated by the parameter name, or null if not found
      * @throws InvalidArgumentException if the parameter does not exist and $required is true
      */
-    public static function orNull($params=[], $paramName, $required = false)
+    public static function orNull($params, $paramName, $required = false)
     {
         if (array_key_exists($paramName, $params)) {
             return $params[$paramName];


### PR DESCRIPTION
PHP >=8.0 delivers a deprecation warning: `PHP Deprecated:  Required parameter $paramName follows optional parameter $params`. Looking at the `orNull` function, there is always a value passed through for `$params`, so this should be a safe change to make required. 