### PR TITLE
Bump guzzle to support version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "issues": "https://community.oracle.com/mosc/"
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^6.5 || ^7",
         "php": ">=5.6",
         "cache/adapter-common": "^1.2"
     },


### PR DESCRIPTION
I have left support for Guzzle 6.5 incase there is a desire to support PHP 5.6 (which is very, very outdated). 

Unfortunately I was not able to run any unit tests as they didn't appear to be in the repository, but I can confirm out implementation is working with PHP 8.1 and Guzzle.